### PR TITLE
More Test Case for Method Invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,12 @@ const mixed2 = age < 18 ? 'youngster' : (age <= 60 ? 'adult' : (age < 100 ? 'eld
 "Hello world".repeat(3)
 "Wyrd Lang is Awesome".upcase()
 (1 + 2 * 3).toStr()
+
+# Chained Invocation
+"Hello".concat(" world").concat(", Wyrd-Lang!")
+
+# Invocation as Parameter
+"Hello".concat(" world".concat(", Wyrd-Lang!"))
 ```
 
 **Compiled Wyrd Code**
@@ -221,6 +227,8 @@ const mixed2 = age < 18 ? 'youngster' : (age <= 60 ? 'adult' : (age < 100 ? 'eld
 ('Hello world').repeat(3);
 ('Wyrd Lang is Aweseom').toUpperCase();
 (1 + (2 * 3)).toString();
+('Hello').concat(' world').concat(' , Wyrd-Lang!');
+('Hello').concat((' world').concat(' , Wyrd-Lang!'));
 ```
 
 ### Function Declaration as Expression

--- a/src/code-generator/constants.ts
+++ b/src/code-generator/constants.ts
@@ -1,7 +1,14 @@
 export const StrMethodsDirectMap = new Map<string, string>([
   ['upcase', 'toUpperCase'],
+  ['downcase', 'toLowerCase'],
   ['repeat', 'repeat'],
   ['toStr', 'toString'],
+  ['at', 'charAt'],
+  ['concat', 'concat'],
+  ['indexOf', 'indexOf'],
+  ['split', 'split'],
+  ['rest', 'slice'],
+  ['between', 'slice'],
 ]);
 
 export const NumMethodsDirectMap = new Map<string, string>([

--- a/src/code-generator/index.ts
+++ b/src/code-generator/index.ts
@@ -200,6 +200,10 @@ ${codeGenFunctionBody(body, args, 2)}
       if (directMethodMapping.has(name)) {
         const mappedName = directMethodMapping.get(name) as string;
         const args = params.map(genExpr).join(commaDelimiter);
+        
+        /* Chained Method no need for parentheses surrounded */
+        if (receiver.type === 'MethodInvokeExpr')
+          return `${genExpr(receiver)}.${mappedName}(${args})`;
         return `(${genExpr(receiver)}).${mappedName}(${args})`;
       }
     }

--- a/src/code-generator/index.ts
+++ b/src/code-generator/index.ts
@@ -1,6 +1,6 @@
 import * as T from '../types';
 import { LogicalBinaryOperators } from '../parser/constants';
-import { MethodsDirectMap } from './method-direct-map';
+import { MethodsDirectMap } from './constants';
 
 function CodeGenerateError(msg: string): never {
   throw new Error(`Code Generation Error: ${msg}`);

--- a/src/examples/builtin-methods.ts
+++ b/src/examples/builtin-methods.ts
@@ -3,6 +3,12 @@ const program = `\
 "Hello world".toStr()
 "Hello world".upcase()
 "Hello world".repeat(3)
+"Hello world".at(3)
+"Hello world".concat("Wyrd lang is awesome!")
+"Hello world".indexOf("world")
+"Hello world".split(" ")
+"Hello world".rest(5)
+"Hello world".between(6, 8)
 
 # Builtin Num methods
 123.toStr()
@@ -15,6 +21,12 @@ const compiled = `\
 ('Hello world').toString();
 ('Hello world').toUpperCase();
 ('Hello world').repeat(3);
+('Hello world').charAt(3);
+('Hello world').concat('Wyrd lang is awesome!');
+('Hello world').indexOf('world');
+('Hello world').split(' ');
+('Hello world').slice(5);
+('Hello world').slice(6, 8);
 (123).toString();
 (true).toString();
 `;

--- a/src/parser/constants.ts
+++ b/src/parser/constants.ts
@@ -147,9 +147,16 @@ export const BuiltinOPActions = new Map<string, OPAction>([
 ]);
 
 export const BuiltinStrMethods = new Map<string, MethodPattern>([
-  ['upcase', { name: 'upcase', inputPattern: '', returnType: 'Str' }],
-  ['repeat', { name: 'repeat', inputPattern: 'Num', returnType: 'Str' }],
-  ['toStr', { name: 'toStr', inputPattern: '', returnType: 'Str' }],
+  ['upcase',   { name: 'upcase',   inputPattern: '',        returnType: 'Str'       }],
+  ['downcase', { name: 'downcase', inputPattern: '',        returnType: 'Str'       }],
+  ['repeat',   { name: 'repeat',   inputPattern: 'Num',     returnType: 'Str'       }],
+  ['toStr',    { name: 'toStr',    inputPattern: '',        returnType: 'Str'       }],
+  ['at',       { name: 'at',       inputPattern: 'Num',     returnType: 'Str'       }],
+  ['concat',   { name: 'concat',   inputPattern: 'Str',     returnType: 'Str'       }],
+  ['indexOf',  { name: 'indexOf',  inputPattern: 'Str',     returnType: 'Num'       }],
+  ['split',    { name: 'split',    inputPattern: 'Str',     returnType: 'List[Str]' }],
+  ['rest',     { name: 'rest',     inputPattern: 'Num',     returnType: 'Str'       }],
+  ['between',  { name: 'between',  inputPattern: 'Num.Num', returnType: 'Str'       }],
 ]);
 
 export const BuiltinNumMethods = new Map<string, MethodPattern>([

--- a/src/samples/method-invocation/as-params.ts
+++ b/src/samples/method-invocation/as-params.ts
@@ -1,0 +1,55 @@
+import { Token, AST } from '../../types';
+import { StringLiteral } from '../helper';
+
+const program = `\
+"Hello world".concat("Wyrd-Lang".concat(" is awesome!"))
+`;
+
+const tokens: Array<Token> = [
+  { type: 'string', value: 'Hello world' },
+  { type: 'dot', value: '.' },
+  { type: 'ident', value: 'concat' },
+  { type: 'lparen', value: '(' },
+  { type: 'string', value: 'Wyrd-Lang' },
+  { type: 'dot', value: '.' },
+  { type: 'ident', value: 'concat' },
+  { type: 'lparen', value: '(' },
+  { type: 'string', value: ' is awesome!' },
+  { type: 'rparen', value: ')' },
+  { type: 'rparen', value: ')' },
+  { type: 'newline', value: '\n' },
+];
+
+const ast: AST = [
+  {
+    type: 'MethodInvokeExpr',
+    name: 'concat',
+    receiver: StringLiteral('Hello world'),
+    params: [
+      {
+        type: 'MethodInvokeExpr',
+        name: 'concat',
+        receiver: StringLiteral('Wyrd-Lang'),
+        params: [
+          StringLiteral(' is awesome!'),
+        ],
+        returnType: 'Str',
+      },
+    ],
+    returnType: 'Str',
+  },
+];
+
+const compiled = `\
+('Hello world').concat(('Wyrd-Lang').concat(' is awesome!'));
+`;
+
+const minified = '(\'Hello world\').concat((\'Wyrd-Lang\').concat(\' is awesome!\'));';
+
+export {
+  program,
+  tokens,
+  ast,
+  compiled,
+  minified,
+};

--- a/src/samples/method-invocation/chained.ts
+++ b/src/samples/method-invocation/chained.ts
@@ -1,0 +1,93 @@
+import { Token, AST, Operator as Op } from '../../types';
+import { NumberLiteral, StringLiteral, Arithmetic } from '../helper';
+
+const program = `\
+"Hello world".upcase().repeat(3)
+(1 + 2 * 3).toStr().repeat(3)
+`;
+
+const tokens: Array<Token> = [
+  { type: 'string', value: 'Hello world' },
+  { type: 'dot', value: '.' },
+  { type: 'ident', value: 'upcase' },
+  { type: 'lparen', value: '(' },
+  { type: 'rparen', value: ')' },
+  { type: 'dot', value: '.' },
+  { type: 'ident', value: 'repeat' },
+  { type: 'lparen', value: '(' },
+  { type: 'number', value: '3' },
+  { type: 'rparen', value: ')' },
+  { type: 'newline', value: '\n' },
+
+  { type: 'lparen', value: '(' },
+  { type: 'number', value: '1' },
+  { type: 'plus', value: '+' },
+  { type: 'number', value: '2' },
+  { type: 'asterisk', value: '*' },
+  { type: 'number', value: '3' },
+  { type: 'rparen', value: ')' },
+  { type: 'dot', value: '.' },
+  { type: 'ident', value: 'toStr' },
+  { type: 'lparen', value: '(' },
+  { type: 'rparen', value: ')' },
+  { type: 'dot', value: '.' },
+  { type: 'ident', value: 'repeat' },
+  { type: 'lparen', value: '(' },
+  { type: 'number', value: '3' },
+  { type: 'rparen', value: ')' },
+  { type: 'newline', value: '\n' },
+];
+
+const ast: AST = [
+  {
+    type: 'MethodInvokeExpr',
+    name: 'repeat',
+    receiver: {
+      type: 'MethodInvokeExpr',
+      name: 'upcase',
+      receiver: StringLiteral('Hello world'),
+      params: [],
+      returnType: 'Str',
+    },
+    params: [
+      NumberLiteral(3),
+    ],
+    returnType: 'Str',
+  },
+  {
+    type: 'MethodInvokeExpr',
+    name: 'repeat',
+    receiver: {
+      type: 'MethodInvokeExpr',
+      name: 'toStr',
+      receiver: {
+        type: 'BinaryOpExpr',
+        operator: Op.Plus,
+        returnType: 'Num',
+        expr1: NumberLiteral(1),
+        expr2: Arithmetic(2, '*', 3),
+      },
+      params: [],
+      returnType: 'Str',
+    },
+    params: [
+      NumberLiteral(3),
+    ],
+    returnType: 'Str',
+  },
+];
+
+const compiled = `\
+('Hello world').toUpperCase().repeat(3);
+(1 + (2 * 3)).toString().repeat(3);
+`;
+
+const minified = '(\'Hello world\').toUpperCase().repeat(3);(1+(2*3)).toString().repeat(3);';
+
+export {
+  program,
+  tokens,
+  ast,
+  compiled,
+  minified,
+};

--- a/src/test/compiler-options/minification.spec.ts
+++ b/src/test/compiler-options/minification.spec.ts
@@ -83,5 +83,6 @@ describe('Compiler Option: Minification', () => {
   describe('Method Invocation', () => {
     perform('method invocation with direct method mapping', 'method-invocation/direct-method-mapping');
     perform('expression invoke method expression', 'method-invocation/expr-invoke-method');
+    perform('chained method invocation', 'method-invocation/chained');
   });
 });

--- a/src/test/compiler-options/minification.spec.ts
+++ b/src/test/compiler-options/minification.spec.ts
@@ -84,5 +84,6 @@ describe('Compiler Option: Minification', () => {
     perform('method invocation with direct method mapping', 'method-invocation/direct-method-mapping');
     perform('expression invoke method expression', 'method-invocation/expr-invoke-method');
     perform('chained method invocation', 'method-invocation/chained');
+    perform('method invocation as parameters', 'method-invocation/as-params');
   });
 });

--- a/src/test/expressions/method-invocation.spec.ts
+++ b/src/test/expressions/method-invocation.spec.ts
@@ -23,4 +23,8 @@ describe('Method Invocation', () => {
   describe('Chained Method Invocation', () => {
     FundamentalCompileTest('method-invocation/chained');
   });
+
+  describe('Method Invocation as Parameters', () => {
+    FundamentalCompileTest('method-invocation/as-params');
+  });
 });

--- a/src/test/expressions/method-invocation.spec.ts
+++ b/src/test/expressions/method-invocation.spec.ts
@@ -19,4 +19,8 @@ describe('Method Invocation', () => {
   describe('Expression then Invokes Method', () => {
     FundamentalCompileTest('method-invocation/expr-invoke-method');
   });
+
+  describe('Chained Method Invocation', () => {
+    FundamentalCompileTest('method-invocation/chained');
+  });
 });


### PR DESCRIPTION
Support more builtin `Str` methods which maps directly to JavaScript's `String.prototype` method

Chained invocation is now available.

```
"Hello world".upcase().repeat()
```