### PR TITLE
Prevent Function Redeclaration

### DIFF
--- a/src/parser/classes/Scope.ts
+++ b/src/parser/classes/Scope.ts
@@ -1,6 +1,4 @@
-import FunctionObject from './Scope.FunctionObject';
-import Variable from './Scope.Variable';
-import DT from './DataType';
+import { Parameter, ScopeVariable as Variable, DataType as DT, ScopeFunctionObject as FunctionObject } from '.';
 import { ParserError } from '../error';
 
 export default class Scope {
@@ -48,6 +46,11 @@ export default class Scope {
     if (functionObj === undefined)
       ParserError(`Function \`${name}\` isn't found in the scope`);
     return functionObj;
+  }
+
+  public getFunctionPattern(name: string, parameter: Parameter) {
+    const functionObj = this.getFunction(name);
+    return functionObj.getPatternInfo(parameter);
   }
 
   public createFunction(name: string): FunctionObject {

--- a/src/parser/function-invocation.ts
+++ b/src/parser/function-invocation.ts
@@ -9,7 +9,6 @@ export function parseFunctionInvokeExpr(
   prevExpr?: T.Expr,
 ): T.FunctionInvokeExpr {
   const name = tt.value;
-  const functionObj = scope.getFunction(name);
 
   const result: T.FunctionInvokeExpr = {
     type: 'FunctionInvokeExpr',
@@ -30,7 +29,7 @@ export function parseFunctionInvokeExpr(
     result.params = parseFunctionParameters(tt, parseExpr, scope);
 
   const inputParameter = Parameter.from(result.params.map(expr => expr.return));
-  const patternInfo = functionObj.getPatternInfo(inputParameter);  
+  const patternInfo = scope.getFunctionPattern(name, inputParameter);  
   if (patternInfo === undefined) {
     ParserError(`Function \`${name}\` is called with unmatched input pattern \`${inputParameter}\``);
   }

--- a/src/parser/function.ts
+++ b/src/parser/function.ts
@@ -40,11 +40,8 @@ export function parseFunctionDeclaration(
 
   /* Check if function is redeclared with same input pattern */
   if (scope.hasFunction(result.name)) {
-    const functionObj = scope.getFunction(result.name);
-    const info = functionObj.getPatternInfo(parameter);
-
     ParserErrorIf(
-      info !== undefined,
+      scope.getFunctionPattern(result.name, parameter) !== undefined,
       `ParserError: Overriding function \`${result.name}\` with existing input pattern \`${parameter}\`; to override the function, address it with \`override\` keyword before \`def\` token`
     );
   }

--- a/src/test/errors/no-function-redeclaration.spec.ts
+++ b/src/test/errors/no-function-redeclaration.spec.ts
@@ -1,0 +1,16 @@
+import { compile } from '../..';
+
+describe('No Function Redeclaration', () => {
+  it('throws error when function is redeclared', () => {
+    const program = `
+def addition(x: Num, y: Num): Num => x + y
+addition(1, 2)
+
+def addition(x: Num, y: Num): Num => (x + y) * 2
+addition(1, 2)
+`;
+
+    expect(() => compile(program))
+      .toThrowError('ParserError: Overriding function `addition` with existing input pattern `Num.Num`; to override the function, address it with `override` keyword before `def` token');
+  });
+});

--- a/src/test/errors/used-unidentified-token.spec.ts
+++ b/src/test/errors/used-unidentified-token.spec.ts
@@ -1,6 +1,6 @@
 import { compile } from '../..';
 
-describe.only('Used Unidentified Token', () => {
+describe('Used Unidentified Token', () => {
   it('throws error when using unidentified token', () => {
     const program1 = `\nfoo = 1 + bar\n`;
     expect(() => compile(program1))


### PR DESCRIPTION
Function redeclaration with identical input parameter pattern is now forbidden. Related to #29.